### PR TITLE
added support for the new DepthMap type

### DIFF
--- a/graph_slam.orogen
+++ b/graph_slam.orogen
@@ -120,9 +120,13 @@ task_context "VelodyneSLAM" do
         doc 'radius of the initial footprint'
 
     ## input ports
-    input_port('lidar_samples', '/velodyne_lidar/MultilevelLaserScan').
+    input_port('lidar_samples', '/base/samples/DepthMap').
         needs_reliable_connection.
         doc 'timestamped 3d laser scans'
+
+    input_port('lidar_samples_deprecated', '/velodyne_lidar/MultilevelLaserScan').
+        needs_reliable_connection.
+        doc 'timestamped 3d laser scans. Note: this type is deprecated!'
         
     input_port('simulated_pointcloud', '/base/samples/Pointcloud').
         needs_reliable_connection.
@@ -154,6 +158,7 @@ task_context "VelodyneSLAM" do
         transformation("body", "odometry")
 
         align_port("lidar_samples", 0.1)
+        align_port("lidar_samples_deprecated", 0.1)
         align_port("simulated_pointcloud", 0.1)
     end
 

--- a/scripts/artemis_velodyne_slam.rb
+++ b/scripts/artemis_velodyne_slam.rb
@@ -62,7 +62,7 @@ Orocos.run "graph_slam::VelodyneSLAM" => "velodyne_slam" do
 
     # connect ports with the task
     velodyne_ports.each do |port|
-        port.connect_to velodyne_slam.lidar_samples, :type => :buffer, :size => 100
+        port.connect_to velodyne_slam.lidar_samples_deprecated, :type => :buffer, :size => 100
     end
     odometry_port.each do |port|
         port.connect_to velodyne_slam.odometry_samples, :type => :buffer, :size => 1000

--- a/scripts/seekur_velodyne_slam.rb
+++ b/scripts/seekur_velodyne_slam.rb
@@ -73,7 +73,7 @@ Orocos.run "graph_slam::VelodyneSLAM" => "velodyne_slam" do
 
     # connect ports with the task
     velodyne_ports.each do |port|
-        port.connect_to velodyne_slam.lidar_samples, :type => :buffer, :size => 100
+        port.connect_to velodyne_slam.lidar_samples_deprecated, :type => :buffer, :size => 100
     end
     odometry_port.each do |port|
         port.connect_to velodyne_slam.odometry_samples

--- a/tasks/VelodyneSLAM.hpp
+++ b/tasks/VelodyneSLAM.hpp
@@ -9,6 +9,8 @@
 #include <envire/core/EventHandler.hpp>
 #include <boost/shared_ptr.hpp>
 #include <graph_slam/extended_sparse_optimizer.hpp>
+#include <base/samples/DepthMap.hpp>
+#include <velodyne_lidar/MultilevelLaserScan.h>
 
 namespace graph_slam {
     
@@ -65,8 +67,11 @@ namespace graph_slam {
         bool integrate_new_samples;
 
     protected:
-        void handleLidarData(const base::Time &ts, const velodyne_lidar::MultilevelLaserScan* lidar_sample, const base::samples::Pointcloud* simulated_pointcloud_sample = NULL);
-        virtual void lidar_samplesTransformerCallback(const base::Time &ts, const ::velodyne_lidar::MultilevelLaserScan &lidar_samples_sample);
+        void handleLidarData(const base::Time &ts, const ::base::samples::DepthMap* lidar_sample,
+                             const base::samples::Pointcloud* simulated_pointcloud_sample = NULL,
+                             const ::velodyne_lidar::MultilevelLaserScan* lidar_sample_deprecated = NULL);
+        virtual void lidar_samplesTransformerCallback(const base::Time &ts, const ::base::samples::DepthMap &lidar_sample);
+        virtual void lidar_samples_deprecatedTransformerCallback(const base::Time &ts, const ::velodyne_lidar::MultilevelLaserScan &lidar_sample_deprecated);
         virtual void simulated_pointcloudTransformerCallback(const base::Time &ts, const ::base::samples::Pointcloud &simulated_pointcloud_sample);
         virtual bool generateMap();
         virtual bool saveEnvironment(::std::string const & path);


### PR DESCRIPTION
DepthMap is the default 3D laser scan type now, but MultilevelLaserScan type is still supported.
To use old log-files the input port lidar_samples_deprecated can be used or the log-files can be converted using rock-convert.

This is related to rock-drivers/drivers-orogen-velodyne_lidar#4
